### PR TITLE
Welcome mat update

### DIFF
--- a/force-app/main/default/aura/WelcomeMatNoModal/WelcomeMatNoModal.cmp
+++ b/force-app/main/default/aura/WelcomeMatNoModal/WelcomeMatNoModal.cmp
@@ -8,7 +8,6 @@
     <aura:attribute name="tileConfigJson" type="String" default="" access="global"/>
     <aura:attribute name="tiles" type="Object[]" default="" access="global"/>
     <aura:handler name="init" value="{!this}" action="{!c.initialize}"/>
-    <div class="demo-only" style="height:800px">
         <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open slds-modal_small"
             aria-labelledby="welcome-mat-100-label" aria-describedby="welcome-mat-100-content" aria-modal="true">
             <div class="slds-modal__container">
@@ -65,7 +64,8 @@
                                 <ul class="slds-welcome-mat__tiles slds-size_1-of-2">
                                     <aura:iteration items="{!v.tiles}" var="theTile">
                                         <li class="slds-welcome-mat__tile">
-                                            <a href="{!theTile.linkUrl!=null?theTile.linkUrl:'#'}" target="_blank" class="slds-box slds-box_link slds-media">
+                                            <div onclick="{!c.onClick}" data-href="{!theTile.linkUrl}"
+                                            class="slds-box slds-box_link slds-media">
                                                 <div
                                                     class="slds-media__figure slds-media__figure_fixed-width slds-align_absolute-center">
                                                     <div class="slds-welcome-mat__tile-figure">
@@ -85,18 +85,15 @@
                                                         </p>
                                                     </div>
                                                 </div>
-                                            </a>
+                                            </div>
                                         </li>
                                     </aura:iteration>
                                 </ul>
                             </aura:if>
-    
-    
                         </div>
                     </div>
                 </div>
             </div>
         </section>
         <div class="slds-backdrop slds-backdrop_open"></div>
-    </div>
 </aura:component>

--- a/force-app/main/default/aura/WelcomeMatNoModal/WelcomeMatNoModalController.js
+++ b/force-app/main/default/aura/WelcomeMatNoModal/WelcomeMatNoModalController.js
@@ -5,6 +5,26 @@
 			
         }
     },
+	
+     onClick: function (cmp, event, helper) {
+        var link = event.currentTarget.dataset.href;
+        var urlEvent = $A.get("e.force:navigateToURL");
+        var internalString = $A.get('$Label.c.InternalString');
+        if (link.includes(internalString)) {
+            urlEvent.setParams({
+                "url": link
+            });
+            urlEvent.fire();
+            cmp.destroy();
+        } else {
+            urlEvent.setParams({
+                "url": link,
+                "target": "_blank"
+            });
+            urlEvent.fire();
+        }
+    },
+	
     closeWelcomeMat : function(cmp, event, helper) {
         if(cmp.get('v.doNotShowAgain') || cmp.get('v.showOnlyOnce')){
             helper.dismissClicked(cmp,event);

--- a/force-app/main/default/aura/WelcomeMatNoModal/WelcomeMatNoModalController.js
+++ b/force-app/main/default/aura/WelcomeMatNoModal/WelcomeMatNoModalController.js
@@ -10,7 +10,9 @@
         var link = event.currentTarget.dataset.href;
         var urlEvent = $A.get("e.force:navigateToURL");
         var internalString = $A.get('$Label.c.InternalString');
-        if (link.includes(internalString)) {
+        if (link == null || link == undefined || link == 'null') {
+            // do nothing
+        } else if (link.includes(internalString)) {
             urlEvent.setParams({
                 "url": link
             });


### PR DESCRIPTION
Hi there Anand,

These changes are so that:

A) The div tag does not create a large space underneath the Welcome Mat such that the page appears not loaded

B) onclick of the Welcome Mat links, if the link is an internal Community link, it does not open a new window, but rather navigates in the same tab without the page reloading.

In your code, you should also add a Custom Label called InternalString with the value "/s/".

Thank you,

Kathryn
kathryn@gscloudsolutions.com